### PR TITLE
Remove undefined character at the end of tex file

### DIFF
--- a/cies-breijs-resume.tex
+++ b/cies-breijs-resume.tex
@@ -266,4 +266,3 @@ From 2003 to 2007 he studied at the Erasmus University Rotterdam and graduated i
 
 \end{document}
 
-＀


### PR DESCRIPTION
Is there a particular reason for that character?
It's in ShareLatex CV template as well